### PR TITLE
fix: Remove autodownsampling from extraArg

### DIFF
--- a/addons/thanos/0.3.x/thanos-3.yaml
+++ b/addons/thanos/0.3.x/thanos-3.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: Addon
+metadata:
+  name: thanos
+  namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.io/name: thanos
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.3.31-1"
+    appversion.kubeaddons.mesosphere.io/thanos: "0.3.31"
+    endpoint.kubeaddons.mesosphere.io/thanos: "/ops/portal/thanos"
+    docs.kubeaddons.mesosphere.io/thanos: "https://thanos.io/getting-started.md/"
+    values.chart.helm.kubeaddons.mesosphere.io/thanos: "https://raw.githubusercontent.com/banzaicloud/banzai-charts/862a85ce67c36afbaf790fe4092d966c21d2bb1c/thanos/values.yaml"
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: prometheus
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: docker
+      enabled: false
+    - name: none
+      enabled: true
+  chartReference:
+    chart: thanos
+    repo: https://kubernetes-charts.banzaicloud.com
+    version: 0.3.31
+    values: |
+      ---
+      store:
+        enabled: true
+      bucket:
+        enabled: false
+      rule:
+        enabled: false
+      compact:
+        enabled: false
+      sidecar:
+        enabled: false
+      query:
+        enabled: true
+        extraArgs:
+          - "--store=prometheus-kubeaddons-prom-prometheus.kubeaddons.svc:10901"
+          - "--query.auto-downsampling"
+          - "--query.partial-response"

--- a/addons/thanos/0.3.x/thanos-3.yaml
+++ b/addons/thanos/0.3.x/thanos-3.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: thanos
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.3.31-1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.3.31-2"
     appversion.kubeaddons.mesosphere.io/thanos: "0.3.31"
     endpoint.kubeaddons.mesosphere.io/thanos: "/ops/portal/thanos"
     docs.kubeaddons.mesosphere.io/thanos: "https://thanos.io/getting-started.md/"
@@ -49,5 +49,4 @@ spec:
         enabled: true
         extraArgs:
           - "--store=prometheus-kubeaddons-prom-prometheus.kubeaddons.svc:10901"
-          - "--query.auto-downsampling"
           - "--query.partial-response"


### PR DESCRIPTION
**What type of PR is this?** Bug
<!-- Bug, Chore, Documentation, Feature -->

**What this PR does/ why we need it**: Having it enabled as extraArg is causing failed deployment.
```
> k logs -f -n kubeaddons thanos-kubeaddons-query-6c9c76fb69-c682d
error parsing commandline arguments: [/bin/thanos query --log.level=info --log.format=logfmt --grpc-address=0.0.0.0:10901 --http-address=0.0.0.0:10902 --query.auto-downsampling --store.sd-dns-resolver=miekgdns --store=dnssrv+_grpc._tcp.thanos-kubeaddons-store-grpc.kubeaddons.svc.cluster.local --store=dnssrv+_grpc._tcp.thanos-kubeaddons-sidecar-grpc.kubeaddons.svc.cluster.local --store.sd-interval=5m --store=prometheus-kubeaddons-prom-prometheus.kubeaddons.svc:10901 --query.auto-downsampling --query.partial-response]: flag 'query.auto-downsampling' cannot be repeated
usage: thanos query [<flags>]
```
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
